### PR TITLE
Diff option; read user's config

### DIFF
--- a/hosts-update
+++ b/hosts-update
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Author:
 #  Héctor Molinero Fernández <me@znt.se>.
-#
+#  https://github.com/zant95/hosts-update
+
 
 # Exit on errors:
 set -eu

--- a/hosts-update
+++ b/hosts-update
@@ -11,7 +11,12 @@ set -o pipefail
 # Configuration:
 DST_HOSTS='/etc/hosts'
 DST_IP='0.0.0.0'
-HEADER="
+HEADER_FILE=~/.config/hosts-update/hosts-header.txt
+if test -r "$HEADER_FILE"; then
+	# read header from file
+	HEADER=$(cat "$HEADER_FILE")
+else
+	HEADER="
 127.0.0.1       localhost $(uname -n)
 255.255.255.255 broadcasthost
 ::1             localhost ip6-localhost ip6-loopback
@@ -21,6 +26,8 @@ ff02::1         ip6-allnodes
 ff02::2         ip6-allrouters
 ff02::3         ip6-allhosts
 "
+fi
+
 SOURCES=(
 	'http://adaway.org/hosts.txt'
 	'http://hosts-file.net/ad_servers.txt'

--- a/hosts-update
+++ b/hosts-update
@@ -50,12 +50,6 @@ BLACKLIST=(
 	'blacklistdomain.example'
 )
 
-# Flag:
-FLAG=''
-if [ $# -eq 1 ]; then
-	FLAG="$1"
-fi
-
 # Messages:
 actionMsg() {
 	printf '\e[1;33m + \e[1;32m%s \e[0m\n' "$@"
@@ -81,6 +75,19 @@ promptMsg() {
 		return 1
 	fi
 }
+
+# Flag:
+USE_DIFF=0
+DIFF_TOOL=vimdiff
+if [ $# -ge 1 ] && [[ "$1" == "diff" ]]; then
+	shift
+	actionMsg "Using $DIFF_TOOL"
+	USE_DIFF=1
+fi
+FLAG=''
+if [ $# -eq 1 ]; then
+	FLAG="$1"
+fi
 
 # Process begins:
 actionMsg 'Configuration:'
@@ -153,11 +160,23 @@ actionMsg 'Parsing lists...'
 		HEADER=$(printf '# %s\n%s\n' "$(date)" "$HEADER")
 		HOSTS=$(printf '%s\n# <blocklist>\n%s\n# </blocklist>' "$HEADER" "$BLOCKLIST")
 
-# Write to disk:
-if [ $EUID -ne 0 ]; then
-	printf '%s\n' "$HOSTS" | sudo tee "$DST_HOSTS" > /dev/null
+if [ $USE_DIFF -eq 1 ]; then
+	# Diff new file with current hosts file
+	temp=$(tempfile)
+	printf '%s\n' "$HOSTS" > $temp
+	if [ $EUID -ne 0 ]; then
+		sudo $DIFF_TOOL $temp "$DST_HOSTS"
+	else
+		$DIFF_TOOL $temp "$DST_HOSTS"
+	fi
+	rm -f $temp
 else
-	printf '%s\n' "$HOSTS" | tee "$DST_HOSTS" > /dev/null
+	# Write to disk:
+	if [ $EUID -ne 0 ]; then
+		printf '%s\n' "$HOSTS" | sudo tee "$DST_HOSTS" > /dev/null
+	else
+		printf '%s\n' "$HOSTS" | tee "$DST_HOSTS" > /dev/null
+	fi
 fi
 
 actionMsg "$(printf '%s\n' "$BLOCKLIST" | wc -l) hosts added!"


### PR DESCRIPTION
Three small changes:
- a comment with the github URL for the project, since some users may copy only the file and forget where it's from
- reading the header from `~/.config/hosts-update/hosts-header.txt`, if this file exists
- a `diff` option, that allows over-zealous users to inspect the changes before they're applied

These changes should not alter the current behaviour of the script in any way.